### PR TITLE
Add support of docker-compose to CI and improve API tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,8 @@ script:
   # one last linter
   - golint -set_exit_status $(go list ./...)
 
+  # Build cmd/api
+  - go build -o apisrv cmd/api
+
   # Run API tests
   - go test -v -race ./apitest/... -host "localhost:8090" -dbhost "localhost:10180"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: go
 
+services:
+  - docker
+
+env:
+  - DOCKER_COMPOSE_VERSION=1.24.0
+
 go:
   - master
   - "1.12"
@@ -13,6 +19,13 @@ matrix:
 
 notifications:
   email: true
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+  - docker-compose up -d zero server
 
 before_script:
   - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/) # All the .go files, excluding vendor/
@@ -35,3 +48,6 @@ script:
 
   # one last linter
   - golint -set_exit_status $(go list ./...)
+
+  # Run API tests
+  - go test -v -race ./apitest/... -host "localhost:8090" -dbhost "localhost:10180"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<a href="https://travis-ci.org/romshark/dgraph_graphql_go">
+	<img src="https://travis-ci.org/romshark/dgraph_graphql_go.svg?branch=master" alt="Travis CI: build status">
+</a>
+
 # Dgraph + GraphQL + Go = API
 - Web-App back-end in 100% [Go](https://golang.org/)
 - GraphQL API based on [graph-gophers/graphql-go](https://github.com/graph-gophers/graphql-go)

--- a/apitest/main_test.go
+++ b/apitest/main_test.go
@@ -11,7 +11,8 @@ import (
 
 // stats represents the global statistics recorder the setups must use
 var stats = setup.NewStatisticsRecorder()
-var dbHost = flag.String("dbhost", "localhost:9080", "database host address")
+var dbHost = flag.String("dbhost", "localhost:10180", "database host address")
+var srvHost = flag.String("host", "localhost:8080", "API server host address")
 
 var tcx setup.TestContext
 
@@ -20,6 +21,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 	tcx.Stats = stats
 	tcx.DBHost = *dbHost
+	tcx.SrvHost = *srvHost
 
 	// Run the tests
 	exitCode := m.Run()

--- a/apitest/setup/setup.go
+++ b/apitest/setup/setup.go
@@ -12,8 +12,9 @@ import (
 
 // TestContext represents a test context
 type TestContext struct {
-	Stats  *StatisticsRecorder
-	DBHost string
+	Stats   *StatisticsRecorder
+	DBHost  string
+	SrvHost string
 }
 
 // TestSetup represents the ArangoDB-based setup of an individual test
@@ -38,7 +39,10 @@ func New(t *testing.T, context TestContext) *TestSetup {
 	debugUsername := "test"
 	debugPassword := "test"
 
-	serverTransport, err := thttp.NewServer(thttp.ServerOptions{})
+	serverTransport, err := thttp.NewServer(thttp.ServerOptions{
+		Host:       context.SrvHost,
+		Playground: false,
+	})
 	if err != nil {
 		t.Fatalf("API server transport init: %s", err)
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,8 @@ services:
         volume:
           nocopy: true
     ports:
-      - 8080:8080
-      - 9080:9080
+      - 10080:8080
+      - 10180:9080
     restart: on-failure
     command: dgraph alpha --my=server:7080 --lru_mb=2048 --zero=zero:5080
   ratel:


### PR DESCRIPTION
Change default API HTTP server address and use a different non-standard database port in API tests.