### PR TITLE
GolangCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,6 @@ before_script:
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.16.0
 
 script:
-  # Run all the tests with the race detector enabled
-  - overalls -project=github.com/romshark/dgraph_graphql_go -covermode=atomic -debug -- -race -v -coverpkg=./...
-  - $HOME/gopath/bin/goveralls -coverprofile=overalls.coverprofile -service=travis-ci -repotoken=$COVERALLS_TOKEN
-
   # go vet is the official Go static analyzer
   - go vet ./...
 
@@ -51,3 +47,7 @@ script:
 
   # Build cmd/api
   - go build -o apisrv cmd/api
+
+  # Run all the tests with the race detector enabled
+  - overalls -project=github.com/romshark/dgraph_graphql_go -covermode=atomic -debug -- -race -v -coverpkg=./...
+  - $HOME/gopath/bin/goveralls -coverprofile=overalls.coverprofile -service=travis-ci -repotoken=$COVERALLS_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ before_install:
 before_script:
   - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/) # All the .go files, excluding vendor/
   - go get golang.org/x/lint/golint                             # Linter
-  - go get honnef.co/go/tools/cmd/megacheck                     # Badass static analyzer/linter
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
   - go get github.com/go-playground/overalls
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.16.0
 
 script:
   # Run all the tests with the race detector enabled
@@ -43,8 +43,8 @@ script:
   # go vet is the official Go static analyzer
   - go vet ./...
 
-  # "go vet on steroids" + linter
-  - megacheck ./...
+  # golangci-link
+  - golangci-lint run ./...
 
   # one last linter
   - golint -set_exit_status $(go list ./...)

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
   - go get github.com/go-playground/overalls
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.16.0
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
 
 script:
   # go vet is the official Go static analyzer

--- a/api/transport/http/tcpKeepAliveListener.go
+++ b/api/transport/http/tcpKeepAliveListener.go
@@ -15,7 +15,11 @@ func (ln tcpKeepAliveListener) Accept() (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	tc.SetKeepAlive(true)
-	tc.SetKeepAlivePeriod(ln.KeepAliveDuration)
+	if err := tc.SetKeepAlive(true); err != nil {
+		return nil, err
+	}
+	if err := tc.SetKeepAlivePeriod(ln.KeepAliveDuration); err != nil {
+		return nil, err
+	}
 	return tc, nil
 }

--- a/apitest/createSessionErr_test.go
+++ b/apitest/createSessionErr_test.go
@@ -19,7 +19,7 @@ func TestCreateSessionErr(t *testing.T) {
 		var query struct {
 			User *gqlmod.User `json:"user"`
 		}
-		debug.QueryVar(
+		require.NoError(t, debug.QueryVar(
 			`query($userId: Identifier!) {
 				user(id: $userId) {
 					sessions {
@@ -31,7 +31,7 @@ func TestCreateSessionErr(t *testing.T) {
 				"userId": string(*user.ID),
 			},
 			&query,
-		)
+		))
 		require.NotNil(t, query.User)
 		require.Len(t, query.User.Sessions, 0)
 	}

--- a/apitest/query_test.go
+++ b/apitest/query_test.go
@@ -18,7 +18,7 @@ func TestQuery(t *testing.T) {
 		var query struct {
 			Users []gqlmod.User `json:"users"`
 		}
-		s.ts.Debug().Query(
+		require.NoError(t, s.ts.Debug().Query(
 			`query {
 				users {
 					id
@@ -28,7 +28,7 @@ func TestQuery(t *testing.T) {
 				}
 			}`,
 			&query,
-		)
+		))
 		require.Len(t, query.Users, len(s.users))
 		for _, actual := range query.Users {
 			require.Contains(t, s.users, *actual.ID)
@@ -43,7 +43,7 @@ func TestQuery(t *testing.T) {
 		var query struct {
 			Users []gqlmod.User `json:"users"`
 		}
-		ts.Debug().Query(
+		require.NoError(t, ts.Debug().Query(
 			`query {
 				users {
 					id
@@ -53,7 +53,7 @@ func TestQuery(t *testing.T) {
 				}
 			}`,
 			&query,
-		)
+		))
 		require.Len(t, query.Users, 0)
 	})
 
@@ -64,7 +64,7 @@ func TestQuery(t *testing.T) {
 		var query struct {
 			Posts []gqlmod.Post `json:"posts"`
 		}
-		s.ts.Debug().Query(
+		require.NoError(t, s.ts.Debug().Query(
 			`query {
 				posts {
 					id
@@ -74,7 +74,7 @@ func TestQuery(t *testing.T) {
 				}
 			}`,
 			&query,
-		)
+		))
 		require.Len(t, query.Posts, len(s.posts))
 		for _, actual := range query.Posts {
 			require.Contains(t, s.posts, *actual.ID)
@@ -89,7 +89,7 @@ func TestQuery(t *testing.T) {
 		var query struct {
 			Posts []gqlmod.Post `json:"posts"`
 		}
-		ts.Debug().Query(
+		require.NoError(t, ts.Debug().Query(
 			`query {
 				posts {
 					id
@@ -99,7 +99,7 @@ func TestQuery(t *testing.T) {
 				}
 			}`,
 			&query,
-		)
+		))
 		require.Len(t, query.Posts, 0)
 	})
 
@@ -113,7 +113,7 @@ func TestQuery(t *testing.T) {
 			var query struct {
 				User *gqlmod.User `json:"user"`
 			}
-			clt.QueryVar(
+			require.NoError(t, clt.QueryVar(
 				`query($userId: Identifier!) {
 					user(id: $userId) {
 						id
@@ -126,7 +126,7 @@ func TestQuery(t *testing.T) {
 					"userId": string(*expected.ID),
 				},
 				&query,
-			)
+			))
 			require.NotNil(t, query.User)
 			compareUsers(t, expected, query.User)
 		}
@@ -139,7 +139,7 @@ func TestQuery(t *testing.T) {
 		var query struct {
 			User *gqlmod.User `json:"user"`
 		}
-		s.ts.Debug().QueryVar(
+		require.NoError(t, s.ts.Debug().QueryVar(
 			`query($userId: Identifier!) {
 				user(id: $userId) {
 					id
@@ -152,7 +152,7 @@ func TestQuery(t *testing.T) {
 				"userId": string(store.NewID()),
 			},
 			&query,
-		)
+		))
 		require.Nil(t, query.User)
 	})
 
@@ -164,7 +164,7 @@ func TestQuery(t *testing.T) {
 			var query struct {
 				Post *gqlmod.Post `json:"post"`
 			}
-			s.ts.Debug().QueryVar(
+			require.NoError(t, s.ts.Debug().QueryVar(
 				`query($postId: Identifier!) {
 					post(id: $postId) {
 						id
@@ -177,7 +177,7 @@ func TestQuery(t *testing.T) {
 					"postId": string(*expected.ID),
 				},
 				&query,
-			)
+			))
 			require.NotNil(t, query.Post)
 			comparePosts(t, expected, query.Post)
 		}
@@ -190,7 +190,7 @@ func TestQuery(t *testing.T) {
 		var query struct {
 			Post *gqlmod.Post `json:"post"`
 		}
-		s.ts.Debug().QueryVar(
+		require.NoError(t, s.ts.Debug().QueryVar(
 			`query($postId: Identifier!) {
 				post(id: $postId) {
 					id
@@ -203,7 +203,7 @@ func TestQuery(t *testing.T) {
 				"postId": string(store.NewID()),
 			},
 			&query,
-		)
+		))
 		require.Nil(t, query.Post)
 	})
 
@@ -215,7 +215,7 @@ func TestQuery(t *testing.T) {
 			var query struct {
 				Reaction *gqlmod.Reaction `json:"reaction"`
 			}
-			s.ts.Debug().QueryVar(
+			require.NoError(t, s.ts.Debug().QueryVar(
 				`query($reactionId: Identifier!) {
 					reaction(id: $reactionId) {
 						id
@@ -228,7 +228,7 @@ func TestQuery(t *testing.T) {
 					"reactionId": string(*expected.ID),
 				},
 				&query,
-			)
+			))
 			compareReactions(t, expected, query.Reaction)
 		}
 	})
@@ -240,7 +240,7 @@ func TestQuery(t *testing.T) {
 		var query struct {
 			Reaction *gqlmod.Reaction `json:"reaction"`
 		}
-		s.ts.Debug().QueryVar(
+		require.NoError(t, s.ts.Debug().QueryVar(
 			`query($reactionId: Identifier!) {
 				reaction(id: $reactionId) {
 					id
@@ -253,7 +253,7 @@ func TestQuery(t *testing.T) {
 				"reactionId": string(store.NewID()),
 			},
 			&query,
-		)
+		))
 		require.Nil(t, query.Reaction)
 	})
 
@@ -265,7 +265,7 @@ func TestQuery(t *testing.T) {
 			var query struct {
 				User *gqlmod.User `json:"user"`
 			}
-			s.ts.Debug().QueryVar(
+			require.NoError(t, s.ts.Debug().QueryVar(
 				`query($userId: Identifier!) {
 					user(id: $userId) {
 						posts {
@@ -280,7 +280,7 @@ func TestQuery(t *testing.T) {
 					"userId": string(authorID),
 				},
 				&query,
-			)
+			))
 
 			require.NotNil(t, query.User)
 			require.Len(t, query.User.Posts, len(posts))
@@ -301,7 +301,7 @@ func TestQuery(t *testing.T) {
 			var query struct {
 				Post *gqlmod.Post `json:"post"`
 			}
-			s.ts.Debug().QueryVar(
+			require.NoError(t, s.ts.Debug().QueryVar(
 				`query($postId: Identifier!) {
 					post(id: $postId) {
 						author {
@@ -316,7 +316,7 @@ func TestQuery(t *testing.T) {
 					"postId": string(postID),
 				},
 				&query,
-			)
+			))
 
 			require.NotNil(t, query.Post)
 			require.NotNil(t, query.Post.Author)
@@ -336,7 +336,7 @@ func TestQuery(t *testing.T) {
 			var query struct {
 				User *gqlmod.User `json:"user"`
 			}
-			clt.QueryVar(
+			require.NoError(t, clt.QueryVar(
 				`query($userId: Identifier!) {
 					user(id: $userId) {
 						sessions {
@@ -349,7 +349,7 @@ func TestQuery(t *testing.T) {
 					"userId": string(*sess.User.ID),
 				},
 				&query,
-			)
+			))
 
 			require.NotNil(t, query.User)
 			require.Len(t, query.User.Sessions, len(expectedSessions))
@@ -381,7 +381,7 @@ func TestQuery(t *testing.T) {
 			var query struct {
 				User *gqlmod.User `json:"user"`
 			}
-			s.ts.Debug().QueryVar(
+			require.NoError(t, s.ts.Debug().QueryVar(
 				`query($userId: Identifier!) {
 					user(id: $userId) {
 						sessions {
@@ -394,7 +394,7 @@ func TestQuery(t *testing.T) {
 					"userId": string(userID),
 				},
 				&query,
-			)
+			))
 			require.NotNil(t, query.User)
 			require.Len(t, query.User.Sessions, 0)
 		}
@@ -408,7 +408,7 @@ func TestQuery(t *testing.T) {
 			var query struct {
 				Post *gqlmod.Post `json:"post"`
 			}
-			s.ts.Debug().QueryVar(
+			require.NoError(t, s.ts.Debug().QueryVar(
 				`query($postId: Identifier!) {
 					post(id: $postId) {
 						reactions {
@@ -423,7 +423,7 @@ func TestQuery(t *testing.T) {
 					"postId": string(postID),
 				},
 				&query,
-			)
+			))
 
 			require.NotNil(t, query.Post)
 			require.Len(t, query.Post.Reactions, len(reactions))
@@ -444,7 +444,7 @@ func TestQuery(t *testing.T) {
 			var query struct {
 				User *gqlmod.User `json:"user"`
 			}
-			s.ts.Debug().QueryVar(
+			require.NoError(t, s.ts.Debug().QueryVar(
 				`query($authorId: Identifier!) {
 					user(id: $authorId) {
 						publishedReactions {
@@ -459,7 +459,7 @@ func TestQuery(t *testing.T) {
 					"authorId": string(authorID),
 				},
 				&query,
-			)
+			))
 
 			require.NotNil(t, query.User)
 			require.Len(t, query.User.PublishedReactions, len(reactions))
@@ -480,7 +480,7 @@ func TestQuery(t *testing.T) {
 			var query struct {
 				Reaction *gqlmod.Reaction `json:"reaction"`
 			}
-			s.ts.Debug().QueryVar(
+			require.NoError(t, s.ts.Debug().QueryVar(
 				`query($subjectReactionId: Identifier!) {
 					reaction(id: $subjectReactionId) {
 						reactions {
@@ -495,7 +495,7 @@ func TestQuery(t *testing.T) {
 					"subjectReactionId": string(subjectReactionID),
 				},
 				&query,
-			)
+			))
 
 			require.NotNil(t, query.Reaction)
 			require.Len(t, query.Reaction.Reactions, len(subReactions))

--- a/store/dgraph/reactionSubject_test.go
+++ b/store/dgraph/reactionSubject_test.go
@@ -74,7 +74,11 @@ func TestReactionSubjectUnMarshal(t *testing.T) {
 	// Invalid type <-> JSON
 	t.Run("JSON_invalid", func(t *testing.T) {
 		require.Panics(t, func() {
-			json.Marshal(dgraph.ReactionSubject{V: "invalid_union_type"})
+			res, err := json.Marshal(
+				dgraph.ReactionSubject{V: "invalid_union_type"},
+			)
+			require.Nil(t, res)
+			require.Error(t, err)
 		})
 		invalidJson := []byte(`{"Foo": "bar", "Baz": 42}`)
 		var u dgraph.ReactionSubject


### PR DESCRIPTION
Use [GolangCI](https://github.com/golangci/golangci-lint) instead of the deprecated megacheck and fix all linter errors.